### PR TITLE
replacing manifest wildcard correctly

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -296,9 +296,9 @@ WebpackMultiOutput.prototype.processSource = function (value, source, callback, 
       replaceSnippetOnSource(_source, snippetToFind, replace.replace);
     });
 
-    var snippetToFind = '"__WEBPACK_MULTI_OUTPUT_VALUE__"';
+    var snippetToFind = '__WEBPACK_MULTI_OUTPUT_VALUE__';
 
-    replaceSnippetOnSource(_source, snippetToFind, '"' + value + '"');
+    replaceSnippetOnSource(_source, snippetToFind, value);
 
     var sourceAndMap = new _webpackSources.SourceMapSource(_source.source(), filename, _source.map());
 

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -262,9 +262,9 @@ WebpackMultiOutput.prototype.processSource = function(value: string, source: Obj
       replaceSnippetOnSource(_source, snippetToFind, replace.replace);
     });
 
-    const snippetToFind = '"__WEBPACK_MULTI_OUTPUT_VALUE__"';
+    const snippetToFind = '__WEBPACK_MULTI_OUTPUT_VALUE__';
 
-    replaceSnippetOnSource(_source, snippetToFind, `"${value}"`);
+    replaceSnippetOnSource(_source, snippetToFind, value);
 
     const sourceAndMap = new SourceMapSource(
       _source.source(),


### PR DESCRIPTION
issue: manifest chunk have a difference in the surroundings of the element to replace against. 
solution: reducing the matching string to catch it as well. 