### PR TITLE
we assume everything can be replaced wrapping with ConcatSource

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -132,14 +132,20 @@ WebpackMultiOutput.prototype.apply = function (compiler) {
           _this.options.values.forEach(function (value) {
             var basename = _path2.default.basename(file, '.js');
             var filename = value + '.' + basename + '.js';
+            var sourceMapFilename = filename + '.map';
 
             _this.processSource(value, (0, _lodash2.default)(source), function (result) {
               _this.log('Add asset ' + filename);
               compilation.assets[filename] = result;
-              compilation.assets[filename + '.map'] = new _webpackSources.RawSource(JSON.stringify(result.map()));
+
               _this.chunksMap[chunk.id] = true;
               _this.addedAssets.push({ value: value, filename: filename, name: chunk.name });
 
+              var sourceMap = result.map();
+
+              if (sourceMap.mappings) {
+                compilation.assets[sourceMapFilename] = new _webpackSources.RawSource(JSON.stringify(sourceMap));
+              }
               if (chunk.name) {
                 if (_this.needsHash) {
                   _this.chunkHash = compilation.getStats().hash;
@@ -268,20 +274,10 @@ WebpackMultiOutput.prototype.getFilePath = function (string) {
 WebpackMultiOutput.prototype.processSource = function (value, source, callback, filename) {
   var _this2 = this;
 
-  var sourceMapSource = void 0;
   var result = void 0;
-  var sourceIndex = void 0;
-  if (source.children) {
-    sourceIndex = source.children.findIndex(function (source) {
-      return source.constructor.name === 'SourceMapSource' || source.constructor.name === 'CachedSource';
-    });
-    sourceMapSource = source.children[sourceIndex];
-  } else {
-    sourceMapSource = source;
-  }
 
-  var matches = sourceMapSource.source().match(this.filePathReG);
-  var _source = new _webpackSources.ReplaceSource(sourceMapSource);
+  var matches = source.source().match(this.filePathReG);
+  var _source = new _webpackSources.ReplaceSource(source, filename);
   var replaces = [];
 
   (0, _async.forEachOfLimit)(matches, 10, function (match, k, cb) {
@@ -292,7 +288,6 @@ WebpackMultiOutput.prototype.processSource = function (value, source, callback, 
   }, function () {
     replaces.forEach(function (replace) {
       var snippetToFind = '"' + replace.source + '"';
-
       replaceSnippetOnSource(_source, snippetToFind, replace.replace);
     });
 
@@ -302,20 +297,11 @@ WebpackMultiOutput.prototype.processSource = function (value, source, callback, 
 
     var sourceAndMap = new _webpackSources.SourceMapSource(_source.source(), filename, _source.map());
 
-    if (source.children) {
-      result = new _webpackSources.ConcatSource();
+    result = new _webpackSources.ConcatSource(sourceAndMap);
 
-      source.children.forEach(function (source, index) {
-        var item = source;
-        if (index === sourceIndex) {
-          item = sourceAndMap;
-        }
-        result.add(item);
-      });
-    } else {
-      result = new _webpackSources.ConcatSource(sourceAndMap);
+    if (result.map().mappings) {
+      result.add(new _webpackSources.RawSource('\n//# sourceMappingURL=' + filename + '.map\n'));
     }
-    result.add(new _webpackSources.RawSource('\n//# sourceMappingURL=' + filename + '.map\n'));
 
     callback(result);
   });


### PR DESCRIPTION
issue: sometimes rawSource would produce errors when replacing matches. 
solution: make a broader assumption that ReplaceSource understands ever source. 