### PR TITLE
Delegating sourcemap creation to Webpack

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -297,7 +297,9 @@ WebpackMultiOutput.prototype.processSource = function (value, source, callback, 
 
     replaceSnippetOnSource(_source, snippetToFind, value);
 
-    result = new _webpackSources.ConcatSource(_source);
+    var sourceAndMap = new _webpackSources.SourceMapSource(_source.source(), filename, _source.map());
+
+    result = new _webpackSources.ConcatSource(sourceAndMap);
 
     callback(result);
   });

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -297,12 +297,6 @@ WebpackMultiOutput.prototype.processSource = function (value, source, callback, 
 
     replaceSnippetOnSource(_source, snippetToFind, value);
 
-    // const sourceAndMap = new SourceMapSource(
-    //   _source.source(),
-    //   filename,
-    //   _source.map()
-    // );
-
     result = new _webpackSources.ConcatSource(_source);
 
     callback(result);

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -138,6 +138,8 @@ WebpackMultiOutput.prototype.apply = function (compiler) {
               _this.log('Add asset ' + filename);
               compilation.assets[filename] = result;
 
+              chunk.files.push(filename);
+
               _this.chunksMap[chunk.id] = true;
               _this.addedAssets.push({ value: value, filename: filename, name: chunk.name });
 
@@ -295,13 +297,13 @@ WebpackMultiOutput.prototype.processSource = function (value, source, callback, 
 
     replaceSnippetOnSource(_source, snippetToFind, value);
 
-    var sourceAndMap = new _webpackSources.SourceMapSource(_source.source(), filename, _source.map());
+    // const sourceAndMap = new SourceMapSource(
+    //   _source.source(),
+    //   filename,
+    //   _source.map()
+    // );
 
-    result = new _webpackSources.ConcatSource(sourceAndMap);
-
-    if (result.map().mappings) {
-      result.add(new _webpackSources.RawSource('\n//# sourceMappingURL=' + filename + '.map\n'));
-    }
+    result = new _webpackSources.ConcatSource(_source);
 
     callback(result);
   });

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -105,6 +105,8 @@ WebpackMultiOutput.prototype.apply = function(compiler: Object): void {
               this.log(`Add asset ${filename}`)
               compilation.assets[filename] = result
 
+              chunk.files.push(filename);
+
               this.chunksMap[chunk.id] = true
               this.addedAssets.push({value, filename, name: chunk.name})
 
@@ -263,17 +265,7 @@ WebpackMultiOutput.prototype.processSource = function(value: string, source: Obj
 
     replaceSnippetOnSource(_source, snippetToFind, value);
 
-    const sourceAndMap = new SourceMapSource(
-      _source.source(),
-      filename,
-      _source.map()
-    );
-
-    result = new ConcatSource(sourceAndMap);
-
-    if (result.map().mappings) {
-      result.add(new RawSource(`\n//# sourceMappingURL=${filename}.map\n`));
-    }
+    result = new ConcatSource(_source);
 
     callback(result);
   })

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -265,7 +265,13 @@ WebpackMultiOutput.prototype.processSource = function(value: string, source: Obj
 
     replaceSnippetOnSource(_source, snippetToFind, value);
 
-    result = new ConcatSource(_source);
+    const sourceAndMap = new SourceMapSource(
+      _source.source(),
+      filename,
+      _source.map()
+    );
+
+    result = new ConcatSource(sourceAndMap);
 
     callback(result);
   })


### PR DESCRIPTION
@gagoar ptal

this should trigger the Webpack sourcemap generation code [here](https://github.com/webpack/webpack/blob/e54af0ddc3246c45602e5738be212ccac0d41a69/lib/SourceMapDevToolPlugin.js#L120-L296) that will deal with putting in `sourceMappingURL` as well as add in project-relative paths like
```
{"version":3,"sources":["webpack:///(webpack)-polyfill-injector/src/injector.js","webpack:///app.a9c635302169e6508c9f.js","webpack:///./node_modules/apollo-fetch/dist/src/apollo-fetch.js","webpack:///./node_modules/@coursera/graphql-utils/node_modules/graphql/validation/rules/UniqueVariableNames.js","webpack:///./node_modules/@coursera/graphql-utils/dist/withFragments.js" ...
```
instead of 
```
{"version":3,"sources":["0.13907c5e88281dd93d8a.js","/codebuild/output/src726787877/src/github.com/webedx-spark/web/static/pages/open-course/peerReview/reviewTypes/structured/partTypes/options/viewConfig.js","/codebuild/output/src726787877/src/github.com/webedx-spark/web/static/bundles/code-evaluator/models/ExecutionTimeSummary.js","/codebuild/output/src726787877/src/github.com/webedx-spark/web/static/bundles/phoenix/components/TopLevelModal.jsx","/codebuild/output/src726787877/src/github.com/webedx-spark/web/node_modules/style-loader/index.js!/codebuild/output/src726787877/src/github.com/webedx-spark/web/node_modules/extract-text-webpack-plugin/dist/loader.js??ref--9-0!/codebuild/output/src726787877/src/github.com/webedx-spark/web/node_modules/style-loader/index.js!/codebuild/output/src726787877/src/github.com/webedx-spark/web/node_modules/cache-loader/dist/cjs.js??ref--9-2!/codebuild/output/src726787877/src/github.com/webedx-spark/web/node_modules/css-loader/index.js!/codebuild/output/src726787877/src/github.com/webedx-spark/web/node_modules/stylus-relative-loader/index.js?paths=/codebuild/output/src726787877/src/github.com/webedx-spark/web/static!/codebuild/output/src726787877/src/github.com/webedx-spark/web/static/bundles/scribe-plugins/scribe-plugin-code-command/components/__styles__/ScribeCodeEditorEvaluatorConfigModal.styl",
```
(the latter causing us issues in Sentry with issue merging)