### PR TITLE
Making sure to only add files when sourcemaps are available

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -138,16 +138,16 @@ WebpackMultiOutput.prototype.apply = function (compiler) {
               _this.log('Add asset ' + filename);
               compilation.assets[filename] = result;
 
-              chunk.files.push(filename);
-
               _this.chunksMap[chunk.id] = true;
               _this.addedAssets.push({ value: value, filename: filename, name: chunk.name });
 
               var sourceMap = result.map();
 
               if (sourceMap.mappings) {
+                chunk.files.push(filename);
                 compilation.assets[sourceMapFilename] = new _webpackSources.RawSource(JSON.stringify(sourceMap));
               }
+
               if (chunk.name) {
                 if (_this.needsHash) {
                   _this.chunkHash = compilation.getStats().hash;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coursera/webpack-multi-output",
-  "version": "3.2.1-0",
+  "version": "3.2.1",
   "description": "Webpack loader and plugin to produce multiple bundle from one import",
   "main": "index.js",
   "author": "Romain Berger <romain@romainberger.com>",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coursera/webpack-multi-output",
-  "version": "3.2.0",
+  "version": "3.2.1-0",
   "description": "Webpack loader and plugin to produce multiple bundle from one import",
   "main": "index.js",
   "author": "Romain Berger <romain@romainberger.com>",

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -105,16 +105,16 @@ WebpackMultiOutput.prototype.apply = function(compiler: Object): void {
               this.log(`Add asset ${filename}`)
               compilation.assets[filename] = result
 
-              chunk.files.push(filename);
-
               this.chunksMap[chunk.id] = true
               this.addedAssets.push({value, filename, name: chunk.name})
 
               const sourceMap = result.map();
 
               if (sourceMap.mappings) {
+                chunk.files.push(filename);
                 compilation.assets[sourceMapFilename] = new RawSource(JSON.stringify(sourceMap));
               }
+
               if (chunk.name) {
                 if (this.needsHash) {
                   this.chunkHash = compilation.getStats().hash


### PR DESCRIPTION
We don't need to re-create chunks if they weren't going to have sourcemaps to begin with.