### PR TITLE
Make plugin work for webpack 4

### DIFF
--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -200,15 +200,26 @@ WebpackMultiOutput.prototype.apply = function (compiler) {
       }, callback);
     });
 
-    compilation.mainTemplate.plugin('jsonp-script', function (_) {
-      var source = _.split('\n');
+    compilation.mainTemplate.hooks.render.tap({
+      name: "JsonpMainTemplatePlugin chunkId replacement",
+      stage: Infinity
+    }, function (rawSource) {
+      var sourceString = rawSource.source();
+      if (!sourceString.includes('chunkId')) {
+        return rawSource;
+      } else {
+        var sourceArray = sourceString.split('\n');
 
-      var chunkIdModifier = 'var webpackMultiOutputGetChunkId = function(chunkId) {\n        var map = {__WEBPACK_MULTI_OUTPUT_CHUNK_MAP__:2};\n        return map[chunkId] ? \'__WEBPACK_MULTI_OUTPUT_VALUE__.\' + chunkId : chunkId;\n      };\n      ';
+        var chunkIdModifier = 'var webpackMultiOutputGetChunkId = function(chunkId) {\n          var map = {__WEBPACK_MULTI_OUTPUT_CHUNK_MAP__:2};\n          return map[chunkId] ? \'__WEBPACK_MULTI_OUTPUT_VALUE__.\' + chunkId : chunkId;\n        };\n        ';
+        var jsonpScriptSrcFunctionIndex = sourceArray.findIndex(function (a) {
+          return a.includes('jsonpScriptSrc');
+        });
 
-      source[9] = source[9].replace('chunkId', 'webpackMultiOutputGetChunkId(chunkId)');
-      source.splice(0, 0, chunkIdModifier);
+        sourceArray[jsonpScriptSrcFunctionIndex + 1] = sourceArray[jsonpScriptSrcFunctionIndex + 1].replace('chunkId', 'webpackMultiOutputGetChunkId(chunkId)');
+        sourceArray.splice(jsonpScriptSrcFunctionIndex + 1, 0, chunkIdModifier);
 
-      return source.join('\n');
+        return sourceArray.join('\n');
+      }
     });
   });
 

--- a/lib/plugin.js
+++ b/lib/plugin.js
@@ -205,9 +205,15 @@ WebpackMultiOutput.prototype.apply = function (compiler) {
       stage: Infinity
     }, function (rawSource) {
       var sourceString = rawSource.source();
-      if (!sourceString.includes('chunkId')) {
+      if (!sourceString.includes('jsonpScriptSrc')) {
         return rawSource;
       } else {
+        // HACK: Find the line containing `jsonpScriptSrc`, which looks like 
+        // /******/ 	function jsonpScriptSrc(chunkId) {
+        // /******/ 		return __webpack_require__.p + "" + ({$CHUNK_ID_TO_NAME_MAP}[chunkId]||chunkId) + ".js"
+        // /******/ 	}
+        // and replace `chunkId` with `webpackMultiOutputGetChunkId(chunkId)`, which attaches the locale 
+        // [specified in `__WEBPACK_MULTI_OUTPUT_CHUNK_MAP__`] if necessary.
         var sourceArray = sourceString.split('\n');
 
         var chunkIdModifier = 'var webpackMultiOutputGetChunkId = function(chunkId) {\n          var map = {__WEBPACK_MULTI_OUTPUT_CHUNK_MAP__:2};\n          return map[chunkId] ? \'__WEBPACK_MULTI_OUTPUT_VALUE__.\' + chunkId : chunkId;\n        };\n        ';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coursera/webpack-multi-output",
-  "version": "3.3.1",
+  "version": "4.0.0",
   "description": "Webpack loader and plugin to produce multiple bundle from one import",
   "main": "index.js",
   "author": "Romain Berger <romain@romainberger.com>",
@@ -34,7 +34,7 @@
     "moment": "^2.13.0",
     "path-exists": "^3.0.0",
     "style-loader": "^0.13.1",
-    "webpack": "^1.13.1",
+    "webpack": "^4.0.0",
     "webpack-rtl-plugin": "^1.1.1"
   },
   "dependencies": {
@@ -45,6 +45,6 @@
     "webpack-sources": "^0.1.1"
   },
   "peerDependencies": {
-    "webpack": "^1.13.1"
+    "webpack": "^4.0.0"
   }
 }

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -167,9 +167,15 @@ WebpackMultiOutput.prototype.apply = function(compiler: Object): void {
 				stage: Infinity
 			}, rawSource => {
       const sourceString = rawSource.source()
-      if (!sourceString.includes('chunkId')) {
+      if (!sourceString.includes('jsonpScriptSrc')) {
         return rawSource;
       } else {
+        // HACK: Find the line containing `jsonpScriptSrc`, which looks like 
+        // /******/ 	function jsonpScriptSrc(chunkId) {
+        // /******/ 		return __webpack_require__.p + "" + ({$CHUNK_ID_TO_NAME_MAP}[chunkId]||chunkId) + ".js"
+        // /******/ 	}
+        // and replace `chunkId` with `webpackMultiOutputGetChunkId(chunkId)`, which attaches the locale 
+        // [specified in `__WEBPACK_MULTI_OUTPUT_CHUNK_MAP__`] if necessary.
         const sourceArray = sourceString.split('\n')
 
         const chunkIdModifier = `var webpackMultiOutputGetChunkId = function(chunkId) {

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -162,6 +162,8 @@ WebpackMultiOutput.prototype.apply = function(compiler: Object): void {
     })
 
     compilation.mainTemplate.hooks.render.tap(
+      // NOTE: the `stage: Infinity` setting is necessary to make this hook run after the code that generates
+      // the webpack runtime, as otherwise we don't have the right content to replace...
       {
 				name: "JsonpMainTemplatePlugin chunkId replacement",
 				stage: Infinity


### PR DESCRIPTION
FYI @jnwng, @gagoar 

This is pretty hacky stuff, especially around the jsonp script that was previously an undocumented hook in webpack 1-3 [https://github.com/dailymotion/webpack-multi-output/blob/master/what.md#jsonp-script] but is registered by `JsonpMainTemplatePlugin.js` [https://github.com/webpack/webpack/blob/master/lib/web/JsonpMainTemplatePlugin.js#L37] which instantiates after this plugin and disallows me to use `mainTemplate.hooks.jsonpScript`...